### PR TITLE
Added macro to silence alarm when sensor disconnected

### DIFF
--- a/TPGSup/Makefile
+++ b/TPGSup/Makefile
@@ -6,6 +6,10 @@ include $(TOP)/configure/CONFIG
 DATA += devTPG300.proto
 DATA += TPG26x.proto
 
+DB += devTPG300.db
+DB += TPG300_channels.db
+DB += unit_setter.db
+
 DB += tpg26x.db
 
 

--- a/TPGSup/TPG300_channels.substitutions
+++ b/TPGSup/TPG300_channels.substitutions
@@ -1,0 +1,9 @@
+file TPG300_channels.template {
+
+pattern {PORT, P, CHAN, IFTEST}
+{"\$(PORT)", "\$(P)", "A1", "\$(IFPRESSURA1)"}
+{"\$(PORT)", "\$(P)", "A2", "\$(IFPRESSURA2)"}
+{"\$(PORT)", "\$(P)", "B1", "\$(IFPRESSURB1)"}
+{"\$(PORT)", "\$(P)", "B2", "\$(IFPRESSURB2)"}
+
+}

--- a/TPGSup/TPG300_channels.template
+++ b/TPGSup/TPG300_channels.template
@@ -1,0 +1,28 @@
+record(ai, "$(P)PRESSURE_$(CHAN)")
+{
+    field(DESC, "Pressure of $(CHAN)")
+    field(SCAN, "1 second")
+    field(DTYP, "stream")
+    field(INP,  "@devTPG300.proto getPressure(P$(CHAN)) $(PORT)")
+    field(PREC, "3")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:PRESSURE")
+    field(SDIS, "$(P)DISABLE")
+	info(archive, "VAL")
+    info(INTEREST, "HIGH")
+    field(EGU, "")
+    $(IFTEST) info(alarm, "Pressure $(CHAN)")
+}
+
+## Visible PVs have initial value set to 0 if the channel is off,
+## or 1 when the channel is on and the VAL field is uncommented
+
+record(bo, "$(P)PRESSURE_$(CHAN):VISIBLE")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+    field(ZNAM, "NO")
+    field(ONAM, "YES")
+    field(PINI, "YES")
+    $(IFTEST) field(VAL, "1")
+}

--- a/TPGSup/devTPG300.db
+++ b/TPGSup/devTPG300.db
@@ -1,0 +1,72 @@
+record(bo, "$(P)DISABLE") 
+{
+    field(DESC, "Disable comms")
+    field(PINI, "YES")
+    field(VAL, "$(DISABLE=0)")
+    field(OMSL, "supervisory")
+    field(ZNAM, "COMMS ENABLED")
+    field(ONAM, "COMMS DISABLED")
+}
+
+## SIMULATION STUFF ##
+
+record(bo, "$(P)SIM") 
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+    field(ZNAM, "NO")
+    field(ONAM, "YES")
+	field(VAL, "$(RECSIM=0)")	
+}
+
+alias("$(P)SIM", "$(P)SIM:SP")
+
+record(mbbi, "$(P)SIM:UNITS") 
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+    field(ZRST, "mbar")
+    field(ONST, "Torr")
+    field(TWST, "Pa")
+}
+
+alias("$(P)SIM:UNITS","$(P)SIM:UNITS:SP")
+
+alias("$(P)SIM:UNITS","$(P)SIM:UNITS:SP:RBV")
+
+record(ai, "$(P)SIM:PRESSURE") 
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+    field(PREC, "3")
+    field(VAL, "1e-6")
+}
+
+## END SIMULATION STUFF ##
+
+record(mbbi, "$(P)UNITS") 
+{
+    field(SCAN, "1 second")
+    field(DTYP, "stream")
+    field(INP,  "@devTPG300.proto getUnits $(PORT)")
+    field(ZRST, "mbar")
+    field(ONST, "Torr")
+    field(TWST, "Pa")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:UNITS")
+    field(SDIS, "$(P)DISABLE")
+}
+
+record(mbbo, "$(P)UNITS:SP") 
+{
+    field(DTYP, "stream")
+    field(OUT,  "@devTPG300.proto setUnits $(PORT)")
+    field(ZRST, "mbar")
+    field(ONST, "Torr")
+    field(TWST, "Pa")
+    field(SIML, "$(P)SIM")
+    field(SIOL, "$(P)SIM:UNITS:SP")
+    field(SDIS, "$(P)DISABLE")
+}
+
+alias("$(P)UNITS", "$(P)UNITS:SP:RBV")

--- a/TPGSup/tpg26x.db
+++ b/TPGSup/tpg26x.db
@@ -140,9 +140,22 @@ record(ai,"$(P)1:PRESSURE") {
    field(DESC, "Pressure reading from gauge 1")
    field(EGU, "") # set by units transfer
    field(PREC, "4")
-   info(alarm, "TPG26x")
+   $(IFPRESSUR1) info(alarm, "TPG26x")
    info(archive, "VAL")
    info(INTEREST, "HIGH")
+}
+
+## PV hidden on graph when value set to 0, or is displayed
+## when the channel is on and the VAL field is uncommented (sets to 1)
+
+record(bo, "$(P)1:VISIBLE")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+    field(ZNAM, "NO")
+    field(ONAM, "YES")
+    field(PINI, "YES")
+    $(IFPRESSUR1) field(VAL, "1")
 }
 
 record(calcout,"$(P)2:CALC_PRES") {
@@ -162,9 +175,22 @@ record(ai,"$(P)2:PRESSURE") {
    field(DESC, "Pressure reading from gauge 2")
    field(EGU, "") # set by units transfer
    field(PREC, "4")
-   info(alarm, "TPG26x")
+   $(IFPRESSUR2)  info(alarm, "TPG26x")
    info(archive, "VAL")
    info(INTEREST, "HIGH")
+}
+
+## PV hidden on graph when value set to 0, or is displayed
+## when the channel is on and the VAL field is uncommented (sets to 1)
+
+record(bo, "$(P)2:VISIBLE")
+{
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+    field(ZNAM, "NO")
+    field(ONAM, "YES")
+    field(PINI, "YES")
+    $(IFPRESSUR2) field(VAL, "1")
 }
 
 record(calc,"$(P)ACTIVITY") {

--- a/TPGSup/unit_setter.substitutions
+++ b/TPGSup/unit_setter.substitutions
@@ -1,0 +1,14 @@
+
+# Set points do not have units set because it will cause it to be processed thus sending a possibly wrong value
+# to the display 
+
+file $(UTILITIES)/db/unit_setter.template { 
+  pattern 
+    {P,    FROM, TO}
+    
+    {"\$(P)", "UNITS", "PRESSURE_A1"}
+    {"\$(P)", "UNITS", "PRESSURE_A2"}
+    {"\$(P)", "UNITS", "PRESSURE_B1"}
+	{"\$(P)", "UNITS", "PRESSURE_B2"}    
+}
+

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -1,3 +1,5 @@
+UTILITIES=$(SUPPORT)/utilities/master
+
 # optional extra local definitions here
 -include $(TOP)/configure/RELEASE.private
 


### PR DESCRIPTION
### Description of work

The alarms of the TPGs can be switched off if their corresponding sensors are not connected. This is to prevent unneccesary alarms.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2578

### Acceptance criteria

- [x] Disconnected alarms from the TPG26x and TPG300 can be ignored
- [x] The disconnected status for each channel can be set as a macro